### PR TITLE
Update build configuration for brainrotguard service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   brainrotguard:
-    build: .
+    build:
+      context: .
+      network: host
     image: brainrotguard
     container_name: brainrotguard
     restart: unless-stopped


### PR DESCRIPTION
Define networking mode for docker compose build step.
Without it, the pip install during build fails.

```
                                                                            0.3s
 => [2/6] WORKDIR /app                                                                                                                                                                                                                  0.1s
 => [3/6] COPY requirements.txt .                                                                                                                                                                                                       0.0s
 => [4/6] RUN pip install --no-cache-dir -r requirements.txt                                                                                                                                                                          123.9s
 => => # WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConn
 => => # ection object at 0x7a76a3f767d0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')': /simple/fastapi/

```